### PR TITLE
fix: handle Tcl raw bytes vs base64 in image export

### DIFF
--- a/NiimPrintX/ui/widget/FileMenu.py
+++ b/NiimPrintX/ui/widget/FileMenu.py
@@ -83,8 +83,12 @@ class FileMenu:
                         pil_image = ImageTk.getimage(font_image_widget)
                     else:
                         # tk.PhotoImage — extract PNG via Tk call
-                        png_b64 = font_image_widget.tk.call(str(font_image_widget), "data", "-format", "png")
-                        pil_image = Image.open(io.BytesIO(base64.b64decode(png_b64)))
+                        png_data = font_image_widget.tk.call(str(font_image_widget), "data", "-format", "png")
+                        # Tcl may return raw bytes or base64 string depending on Tk version
+                        if isinstance(png_data, bytes):
+                            pil_image = Image.open(io.BytesIO(png_data))
+                        else:
+                            pil_image = Image.open(io.BytesIO(base64.b64decode(png_data)))
                     with io.BytesIO() as buffer:
                         pil_image.save(buffer, format="PNG")
                         buffer.seek(0)

--- a/NiimPrintX/ui/widget/PrintOption.py
+++ b/NiimPrintX/ui/widget/PrintOption.py
@@ -179,7 +179,7 @@ class PrintOption:
 
     def export_to_png(
         self, output_filename: str | None = None, horizontal_offset: float = 0.0, vertical_offset: float = 0.0
-    ) -> Image.Image | None:
+    ) -> Image.Image | bool | None:
         if cairo is None:
             raise ImportError("GUI extras not installed. Run: pip install NiimPrintX[gui]")
         if self.canvas_state.canvas is None or self.canvas_state.bounding_box is None:
@@ -229,10 +229,13 @@ class PrintOption:
                         resized_image = ImageTk.getimage(font_img_widget)
                     else:
                         # tk.PhotoImage (from Wand text) — extract via Tcl
-                        import base64 as b64  # noqa: PLC0415 — lazy import; only needed for tk.PhotoImage path
-
-                        png_b64 = font_img_widget.tk.call(str(font_img_widget), "data", "-format", "png")
-                        resized_image = Image.open(io.BytesIO(b64.b64decode(png_b64)))
+                        png_data = font_img_widget.tk.call(str(font_img_widget), "data", "-format", "png")
+                        # Tcl may return raw bytes or base64 string depending on Tk version
+                        if isinstance(png_data, bytes):
+                            resized_image = Image.open(io.BytesIO(png_data))
+                        else:
+                            import base64 as b64  # noqa: PLC0415 — lazy import
+                            resized_image = Image.open(io.BytesIO(b64.b64decode(png_data)))
                     with io.BytesIO() as buffer:
                         resized_image.save(buffer, format="PNG")
                         buffer.seek(0)
@@ -249,7 +252,7 @@ class PrintOption:
                 cropped_ctx.paint()
                 if output_filename:
                     cropped_surface.write_to_png(output_filename)
-                    return None
+                    return True  # Success - file written
                 stride = cropped_surface.get_stride()
                 image_bytes = bytes(cropped_surface.get_data())  # copy before finish()
                 return Image.frombuffer(

--- a/README.md
+++ b/README.md
@@ -78,20 +78,30 @@ To include the optional GUI dependencies (Tkinter theme):
 poetry install --extras gui
 ```
 
-After installation, two console entry points are available:
+After installation, two console entry points are available via Poetry's virtualenv:
 
 ```shell
-niimprintx --help    # CLI interface
-niimprintx-ui        # GUI application
+poetry run niimprintx --help    # CLI interface
+poetry run niimprintx-ui        # GUI application
 ```
 
-These are the recommended way to run NiimPrintX. The `python -m` invocations shown in the Usage section below also work.
+These are the recommended way to run NiimPrintX. The `python -m` invocations shown in the Usage section below also work (prefix with `poetry run`).
 
 ### Note:
 
 **ImageMagick** is only required for the GUI (`--extras gui`). The CLI works without it.
 
-macOS specific setup for local development:
+### Platform-Specific Setup
+
+**Linux (Debian/Ubuntu):**
+
+The GUI requires tkinter and system libraries for Cairo and GObject introspection:
+
+```shell
+sudo apt install python3-tk libcairo2-dev libgirepository1.0-dev pkg-config
+```
+
+**macOS:**
 
 ```shell
 brew install libffi
@@ -146,7 +156,7 @@ The CLI allows you to print images and get information about the printer models.
 
 #### General CLI Usage
 ```shell
-Usage: python -m NiimPrintX.cli [OPTIONS] COMMAND [ARGS]...
+Usage: poetry run niimprintx [OPTIONS] COMMAND [ARGS]...
 
 Options:
   -v, --verbose  Enable verbose logging
@@ -158,7 +168,7 @@ Commands:
 ```
 #### Print Command
 ```shell
-Usage: python -m NiimPrintX.cli print [OPTIONS]
+Usage: poetry run niimprintx print [OPTIONS]
 
 Options:
   -m, --model [b1|b18|b21|d11|d11_h|d110|d101|d110_m]
@@ -174,13 +184,13 @@ Options:
 **Example:**
 
 ```shell
-python -m NiimPrintX.cli print -m d110 -d 3 -n 1 -r 90 -i path/to/image.png
+poetry run niimprintx print -m d110 -d 3 -n 1 -r 90 -i path/to/image.png
 ```
 
 #### Info Command
 
 ```shell
-Usage: python -m NiimPrintX.cli info [OPTIONS]
+Usage: poetry run niimprintx info [OPTIONS]
 
 Options:
   -m, --model [b1|b18|b21|d11|d11_h|d110|d101|d110_m]
@@ -191,7 +201,7 @@ Options:
 **Example:**
 
 ```shell
-python -m NiimPrintX.cli info -m d110
+poetry run niimprintx info -m d110
 ```
 
 ### Graphical User Interface (GUI)
@@ -199,7 +209,7 @@ python -m NiimPrintX.cli info -m d110
 The GUI application allows users to design labels based on the label device and label size. Simply run the GUI application:
 
 ```shell
-python -m NiimPrintX.ui
+poetry run niimprintx-ui
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
- Cherry-picked from `wip/d110m-v4-and-tcl-fix` so the shippable UI fix lands on main without the still-broken D110_M V4 WIP commit.
- Tcl returns either raw bytes or a base64 string depending on Tk version when exporting PhotoImage; handle both in `FileMenu.py` and `PrintOption.py`.
- Return `True` from `PrintOption.prepare_image_for_print` on successful file write.
- README: CLI examples prefixed with `poetry run` to match the dev workflow.