### PR TITLE
fix(NiimPrintX): heartbeat state sync (FR-230) + README version (FR-229)

### DIFF
--- a/NiimPrintX/ui/widget/PrinterOperation.py
+++ b/NiimPrintX/ui/widget/PrinterOperation.py
@@ -72,4 +72,8 @@ class PrinterOperation:
         except Exception as e:
             logger.error(f"Heartbeat error: {e}")
             self._client = None
+            # Keep the connection-state flag in sync with the (now cleared)
+            # client so a consumer checking printer_connected can't see a stale
+            # "connected" after a heartbeat failure.
+            self.printer.printer_connected = False
             return False, {}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Since forking, we have:
 - Replaced the pickle-based `.niim` file format with a secure JSON-based format
 - Introduced user-configurable custom label sizes, per-device rotation, and BLE resilience improvements
 
-**Current version: v0.9.0**
+**Current version: v0.9.1**
 
 A huge thank you to [labbots](https://github.com/labbots) for creating NiimPrintX and building the foundation this project stands on.
 

--- a/tests/test_printer_operation.py
+++ b/tests/test_printer_operation.py
@@ -217,7 +217,7 @@ async def test_heartbeat_no_printer():
 
 
 async def test_heartbeat_failure_clears_printer():
-    """When heartbeat() raises, printer should be set to None."""
+    """When heartbeat() raises, the client is cleared and printer_connected is synced to False."""
     printer = _make_state(printer_connected=True)
     op = PrinterOperation(printer)
     op._client = _make_mock_printer()
@@ -228,6 +228,8 @@ async def test_heartbeat_failure_clears_printer():
     assert success is False
     assert hb == {}
     assert op._client is None
+    # Regression (FR-230): connection-state flag must not stay stale-True.
+    assert printer.printer_connected is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses four Fleet Review findings. Two required code changes; two were already resolved by the post-review refactor and are verified below.

## Fixed

### FR-230 (#48578, P2) — heartbeat nulls _client without syncing printer_connected
`PrinterOperation.heartbeat()` set `self._client = None` on a heartbeat exception but left `printer.printer_connected` untouched, so a consumer reading `printer_connected` could observe a stale "connected" state. Added `self.printer.printer_connected = False` in the exception handler and extended `test_heartbeat_failure_clears_printer` with a regression assertion.

### FR-229 (#48577, P2) — README version drift
README "Current version" said v0.9.0; `pyproject.toml` is 0.9.1. Updated the README.

## Verified already-resolved (no change needed)

### FR-126 (#48161) — print_image vs print_image_v2 protocol selection
Both public methods now delegate to a single `_print_job(..., v2=<bool>)`; protocol selection (start_print vs start_print_v2, set_dimension vs set_dimension_v2) is unified in that one path. The ticket cited the old `niimprintx/` layout, since refactored. Nothing to change.

### FR-125 (#48160) — notification_handler thread safety
`notification_handler` (now `nimmy/printer.py`, not `bluetooth.py`) marshals into the event loop via `self._loop.call_soon_threadsafe(_set)` and sets an `asyncio.Event` — it does **not** call `future.set_result` from the BLE callback thread. It also guards `_loop is None` and catches `RuntimeError` on a closed loop. Already thread-safe.

## Verification
- `pytest tests/ --cov=NiimPrintX` → **366 passed**, coverage **91.15%** (≥90% gate).
- `ruff check` clean on changed files.

Closes #48578, #48577, #48161, #48160.
