### PR TITLE
chore: pin flake8 to 7.3.0 in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,7 +30,12 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        # flake8 is PINNED: its first invocation below (--select=E9,F63,F7,F82)
+        # gates the build, and linters add rules across releases — unpinned, a
+        # flake8 release turns into a red build on a day nobody touched this repo.
+        # 7.3.0 verified clean against this tree. pytest is left unconstrained as
+        # before; it does not add rules, so pinning it is a separate decision.
+        pip install flake8==7.3.0 pytest
         # Install core dependencies (excluding macOS-specific packages)
         if [ -f requirements-ci.txt ]; then pip install -r requirements-ci.txt; fi
     - name: Lint with flake8


### PR DESCRIPTION
`pip install flake8 pytest` installed **whatever released most recently**, and the first flake8 invocation (`--select=E9,F63,F7,F82`) **gates the build**.

Linters add rules across releases, so unpinned this turns a flake8 release into a red build on a day nobody touched the repo — with the blame landing on whoever opens the next PR. `kronos-mcp` hit exactly this shape with ruff and sat red for a week (Redmine #49587).

## Verified at the pin

Using CI's exact commands against this tree:

| run | result |
|---|---|
| `--select=E9,F63,F7,F82` (**blocking**) | `0` |
| `--exit-zero ...` (advisory) | `28`, unchanged |

`pytest` is deliberately left unconstrained, exactly as before — it doesn't add rules, so pinning it is a separate decision.

## One note for whoever touches this next

This workflow is the odd one out. The project's real linter is **ruff** (`ruff.toml`, `ruff ^0.15` in pyproject) — flake8 survives only here. Retiring this workflow in favour of ruff would remove the tool entirely rather than pin it, but that's a bigger change than this one.